### PR TITLE
Improving tests (date and tidy-service)

### DIFF
--- a/src/services/tidy-service.php
+++ b/src/services/tidy-service.php
@@ -7,8 +7,8 @@ class Tidy_Service {
     $content = self::normalize_html_string( $content_excerpt );
     $content = trim( $content );
     // If we only have 1 paragraph and less than $words words, reset the content
-    // to the full event content
-    if ( count( explode( ' ', $content ) ) < $words ) {
+    // to the full content
+    if ( count( explode( ' ', $content ) ) <= $words ) {
         return $content;
     } else {
       // We have some trimming to do

--- a/tests/unit/date-utilities-test.php
+++ b/tests/unit/date-utilities-test.php
@@ -6,6 +6,12 @@ namespace Nectary\Tests;
  * @group utility
  */
 class Date_Utilities_Test extends \PHPUnit_Framework_TestCase {
+
+  protected function setUp() {
+    // Our test cases assume a UTC timezone is defined
+    date_default_timezone_set( 'UTC' );
+  }
+
   function test_date_turns_into_correct_calendar_representation() {
     $timestamp     = '1441746685';
     $expected_date = '20150908T211125';

--- a/tests/unit/tidy-service-test.php
+++ b/tests/unit/tidy-service-test.php
@@ -58,6 +58,10 @@ class Tidy_Service_Test extends \PHPUnit_Framework_TestCase {
     $this->assertEquals( 'more than...', $this->tidy_service->excerpt( '<p>more than two words', 2 ) );
   }
 
+  function test_excerpt_doesnt_return_too_many_periods() {
+    $this->assertEquals( 'more than...', $this->tidy_service->excerpt( '<p>more than. two words', 2 ) );
+  }
+
   function test_fallback_on_tidy_parse_string_library_missing() {
     // TODO: test the behavior when the global function tidy_parse_string isn't defined
   }

--- a/tests/unit/tidy-service-test.php
+++ b/tests/unit/tidy-service-test.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Nectary\Tests;
+
+use Nectary\Services\Tidy_Service;
+
+/**
+ * @group service
+ */
+class Tidy_Service_Test extends \PHPUnit_Framework_TestCase {
+  private $tidy_service;
+  private $tidy_service_mock;
+
+  protected function setUp() {
+    $this->tidy_service = new Tidy_Service();
+    $this->tidy_service_mock = $this->getMockBuilder( 'Nectary\Services\Tidy_Service' )
+      ->setMethods( [ 'excerpt', 'normalize_html_string', 'tidy_parse_string'] )
+      ->getMock();
+  }
+
+  function test_normalize_html_string_with_empty_string() {
+    $this->assertEquals( '', $this->tidy_service->normalize_html_string(' ') );
+  }
+
+  function test_normalize_html_string_in_html_tags() {
+    $this->assertEquals( 'content', $this->tidy_service->normalize_html_string( '<p> content </p>' ) );
+  }
+
+  function test_normalize_html_string_can_urldecode() {
+    $this->assertEquals( '&', $this->tidy_service->normalize_html_string( '&amp;' ) );
+  }
+
+  function test_normalize_html_string_can_urldecode_and_return_html() {
+    $this->assertEquals( '<b>word</b>', $this->tidy_service->normalize_html_string( '&lt;b&gt;word&lt;/b&gt;' ) );
+  }
+
+  function test_normalize_html_string_can_prevent_multiple_spaces() {
+    $this->assertEquals( 'foo bar', $this->tidy_service->normalize_html_string( ' foo    bar' ) );
+  }
+
+  function test_excerpt_that_is_short_of_the_max_lenght() {
+    $this->assertEquals( 'two words', $this->tidy_service->excerpt( 'two words', 50 ) );
+  }
+
+  function test_excerpt_with_the_exact_lenght() {
+    $this->assertEquals( 'two words', $this->tidy_service->excerpt( 'two words', 2 ) );
+  }
+
+  function test_excerpt_that_is_too_long() {
+    $this->assertEquals( 'two...', $this->tidy_service->excerpt( 'two words', 1 ) );
+  }
+
+  function test_excerpt_removes_html() {
+    $this->assertEquals( 'two words', $this->tidy_service->excerpt( '<p>two words</p>', 2 ) );
+  }
+
+  function test_excerpt_doesnt_return_invalid_html() {
+    $this->assertEquals( 'more than...', $this->tidy_service->excerpt( '<p>more than two words', 2 ) );
+  }
+
+  function test_fallback_on_tidy_parse_string_library_missing() {
+    // TODO: test the behavior when the global function tidy_parse_string isn't defined
+  }
+}


### PR DESCRIPTION
Improved test coverage for tidy-service. 
The timezone specification should be in all php setups, however if you happen to have it set to not UTC you get a test failure because the date() will convert to whatever the local timezone is.
