### PR TITLE
Supporting multiple view paths in configuration singleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ php:
   - 5.6
   - 7.0
 
+# Cache composer
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
 install:
   - composer install --no-interaction --prefer-source
   - composer create-project wp-coding-standards/wpcs:dev-master --no-dev -n standards/wpcs

--- a/src/configuration/configuration.php
+++ b/src/configuration/configuration.php
@@ -37,15 +37,15 @@ class Configuration extends Singleton {
     $this->attributes[ $key ] = $value;
   }
 
-  /** 
-   * add to an new or existing value. 
+  /**
+   * Add to an new or existing value.
    * This will promote scalor values into an array to contain multiple values.
    */
   public function add( $key, $value ) {
     if ( ! array_key_exists( $key, $this->attributes ) ) {
       $this->attributes[ $key ] = $value;
     } else {
-      if( ! is_array( $this->attributes[ $key ] ) ) {
+      if ( ! is_array( $this->attributes[ $key ] ) ) {
         $this->attributes[ $key ] = array( $this->attributes[ $key ], $value );
       } else {
         array_push( $this->attributes[ $key ], $value );

--- a/src/configuration/configuration.php
+++ b/src/configuration/configuration.php
@@ -37,6 +37,22 @@ class Configuration extends Singleton {
     $this->attributes[ $key ] = $value;
   }
 
+  /** 
+   * add to an new or existing value. 
+   * This will promote scalor values into an array to contain multiple values.
+   */
+  public function add( $key, $value ) {
+    if ( ! array_key_exists( $key, $this->attributes ) ) {
+      $this->attributes[ $key ] = $value;
+    } else {
+      if( ! is_array( $this->attributes[ $key ] ) ) {
+        $this->attributes[ $key ] = array( $this->attributes[ $key ], $value );
+      } else {
+        array_push( $this->attributes[ $key ], $value );
+      }
+    }
+  }
+
   /**
    * Load in the configuration file and parse it
    */

--- a/src/factories/implementations/view-factory.php
+++ b/src/factories/implementations/view-factory.php
@@ -196,13 +196,13 @@ class View_Factory extends Factory {
     }
   }
 
-  /** 
+  /**
    * Find the first file extention that matches the for this view template
    */
   private function get_file_extension( $view_root, $template_name ) {
     $paths = to_array( Configuration::get_instance()->get( 'path_to_views' ) );
 
-    foreach($paths as $path ) {
+    foreach ( $paths as $path ) {
       if ( ! empty( $view_root ) ) {
         $path .= '/' . $view_root;
       }

--- a/src/factories/implementations/view-factory.php
+++ b/src/factories/implementations/view-factory.php
@@ -196,19 +196,23 @@ class View_Factory extends Factory {
     }
   }
 
+  /** 
+   * Find the first file extention that matches the for this view template
+   */
   private function get_file_extension( $view_root, $template_name ) {
-    $path = Configuration::get_instance()->get( 'path_to_views' );
+    $paths = to_array( Configuration::get_instance()->get( 'path_to_views' ) );
 
-    if ( ! empty( $view_root ) ) {
-      $path .= '/' . $view_root;
-    }
+    foreach($paths as $path ) {
+      if ( ! empty( $view_root ) ) {
+        $path .= '/' . $view_root;
+      }
 
-    $path .= '/' . $template_name;
+      $path .= '/' . $template_name;
 
-    $files = glob( $path . '.*' );
-
-    foreach ( $files as $filename ) {
-      return pathinfo( $filename, PATHINFO_EXTENSION );
+      $files = glob( $path . '.*' );
+      foreach ( $files as $filename ) {
+        return pathinfo( $filename, PATHINFO_EXTENSION );
+      }
     }
 
     return '';

--- a/src/view/extensions/handlebars-view.php
+++ b/src/view/extensions/handlebars-view.php
@@ -33,13 +33,13 @@ abstract class Handlebars_View extends View {
         $this->view_root = $view_root . '/';
       }
 
-      if( null == $path_to_views ) {
+      if ( null == $path_to_views ) {
         $dir = Configuration::get_instance()->get( 'path_to_views' );
       } else {
         $dir = $path_to_views;
       }
 
-      if( is_array( $dir ) ) {
+      if ( is_array( $dir ) ) {
         $paths_to_load_views = array_map( function( $item ) {
             return $item . '/' . $this->view_root;
         }, $dir );

--- a/src/view/extensions/handlebars-view.php
+++ b/src/view/extensions/handlebars-view.php
@@ -21,9 +21,9 @@ abstract class Handlebars_View extends View {
    *
    * @constructor
    * @param $view_root String|Boolean Use false if you are not using views
-   * @param $path_to_view String|Boolean Use to override the path to the views
+   * @param $path_to_view String|Array Use to override the path to the views
    */
-  protected function __construct( $view_root = '' ) {
+  protected function __construct( $view_root = '', $path_to_views = null ) {
     if ( false === $view_root ) {
       // False means we are not loading from a template!
       $loader = new \Handlebars\Loader\StringLoader();
@@ -33,12 +33,24 @@ abstract class Handlebars_View extends View {
         $this->view_root = $view_root . '/';
       }
 
-      $dir = Configuration::get_instance()->get( 'path_to_views' );
+      if( null == $path_to_views ) {
+        $dir = Configuration::get_instance()->get( 'path_to_views' );
+      } else {
+        $dir = $path_to_views;
+      }
+
+      if( is_array( $dir ) ) {
+        $paths_to_load_views = array_map( function( $item ) {
+            return $item . '/' . $this->view_root;
+        }, $dir );
+      } else {
+        $paths_to_load_views = $dir . '/' . $this->view_root;
+      }
 
       $this->engine = new \Handlebars\Handlebars(
           array(
-            'loader' => new \Handlebars\Loader\FilesystemLoader( $dir . '/' . $this->view_root ),
-            'partials_loader' => new \Handlebars\Loader\FilesystemLoader( $dir . '/' . $this->view_root ),
+            'loader' => new \Handlebars\Loader\FilesystemLoader( $paths_to_load_views ),
+            'partials_loader' => new \Handlebars\Loader\FilesystemLoader( $paths_to_load_views ),
           )
       );
     }

--- a/tests/unit/configuration-test.php
+++ b/tests/unit/configuration-test.php
@@ -120,4 +120,18 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
     Configuration::get_instance()->set( 'newkey', 'newvalue' );
     $this->assertEquals( 'newvalue', Configuration::get_instance()->get( 'newkey' ) );
   }
+
+  function test_configuration_can_add_single_value() {
+    Configuration::get_instance()->add( 'newkey', 'newvalue' );
+    $this->assertEquals( 'newvalue', Configuration::get_instance()->get( 'newkey' ) );
+  }
+
+  function test_configuration_can_add_multiple_values() {
+    Configuration::get_instance()->add( 'newkey', 'newvalue' );
+    Configuration::get_instance()->add( 'newkey', 'anothervalue' );
+    Configuration::get_instance()->add( 'newkey', 'andanother' );
+    $this->assertEquals( array( 'newvalue', 'anothervalue', 'andanother' ), 
+      Configuration::get_instance()->get( 'newkey' ) );
+  }
+
 }

--- a/tests/unit/view-factory-test.php
+++ b/tests/unit/view-factory-test.php
@@ -5,11 +5,19 @@ namespace Nectary;
 use Nectary\Factories\View_Factory;
 use Nectary\Configuration;
 
+/**
+ * View Factory Test
+ *
+ * @group view_factory
+ * @group view
+ */
 class View_Factory_Test extends \PHPUnit_Framework_TestCase {
   protected $view_factory;
 
   function setUp() {
     $this->view_factory = new View_Factory( 'na' );
+    // prevent any configuration changes going between tests 
+    Configuration::get_instance()->reset();
   }
 
   function test_can_add_data_and_calls() {
@@ -60,4 +68,19 @@ class View_Factory_Test extends \PHPUnit_Framework_TestCase {
     $view_factory = new View_Factory( 'view.inner.na' );
     $view_factory->build();
   }
+
+  function test_build_uses_multiple_paths_given_configuration() {
+    Configuration::get_instance()->add( 'path_to_views', 'test_path1' );
+    Configuration::get_instance()->add( 'path_to_views', 'test_path2' );
+
+    $mock = create_function_mock( $this, 'glob', 1 );
+    $mock->with($this->logicalOr(
+                 $this->equalTo('test_path1/na.*'  ),
+                 $this->equalTo('test_path2/na.*'  )
+             ))
+            ->will($this->returnValue( [] ));
+
+    $this->view_factory->build();
+  }
+
 }


### PR DESCRIPTION
Configuration Singleton now has an `add` method which will append to what values are already set.
To support multiple nectary projects running in the same php environment that want to use the view templating that Nectary provides. 

Solves #73 