### PR TITLE
better support for multiple view paths

### DIFF
--- a/src/factories/implementations/view-factory.php
+++ b/src/factories/implementations/view-factory.php
@@ -34,11 +34,14 @@ class View_Factory extends Factory {
    *
    * @constructor
    * @param $view_name String The 'path'-like string to the view.
+   * @param $path_to_views String An actual directory path that will override 
+   *  the global nectary configuration.
    */
-  public function __construct( $view_name ) {
+  public function __construct( $view_name, $path_to_views = null ) {
     $this->view_name = $view_name;
     $this->view_data = [];
     $this->head_data = [];
+    $this->path_to_views = $path_to_views;
   }
 
   /**
@@ -141,7 +144,8 @@ class View_Factory extends Factory {
                   $template_name,
                   $view_data
               );
-            }
+            },
+            $this->path_to_views
         );
         $content = $view->output();
         break;
@@ -197,10 +201,21 @@ class View_Factory extends Factory {
   }
 
   /**
+   * Get the path to the views, either the configuration path or the overridden path
+   */
+  private function get_path_to_views() {
+    if( null !== $this->path_to_views ) {
+      return $this->path_to_views;
+    } else {
+      return Configuration::get_instance()->get( 'path_to_views' );
+    }
+  }
+
+  /**
    * Find the first file extention that matches the for this view template
    */
   private function get_file_extension( $view_root, $template_name ) {
-    $paths = to_array( Configuration::get_instance()->get( 'path_to_views' ) );
+    $paths = to_array( $this->get_path_to_views() );
 
     foreach ( $paths as $path ) {
       if ( ! empty( $view_root ) ) {

--- a/src/factories/implementations/view-factory.php
+++ b/src/factories/implementations/view-factory.php
@@ -34,7 +34,7 @@ class View_Factory extends Factory {
    *
    * @constructor
    * @param $view_name String The 'path'-like string to the view.
-   * @param $path_to_views String An actual directory path that will override 
+   * @param $path_to_views String An actual directory path that will override
    *  the global nectary configuration.
    */
   public function __construct( $view_name, $path_to_views = null ) {
@@ -169,14 +169,14 @@ class View_Factory extends Factory {
    *   get_template_name() returns 'blah/foo'
    */
   private function get_template_name() {
-    return str_replace('.', '/' , $this->view_name );
+    return str_replace( '.', '/' , $this->view_name );
   }
 
   /**
    * Get the path to the views, either the configuration path or the overridden path
    */
   private function get_path_to_views() {
-    if( null !== $this->path_to_views ) {
+    if ( null !== $this->path_to_views ) {
       return $this->path_to_views;
     } else {
       return Configuration::get_instance()->get( 'path_to_views' );

--- a/src/factories/implementations/view-factory.php
+++ b/src/factories/implementations/view-factory.php
@@ -128,7 +128,7 @@ class View_Factory extends Factory {
    * @override
    */
   public function build() {
-    $view_root      = $this->get_view_root();
+    $view_root      = '';
     $template_name  = $this->get_template_name();
     $file_extension = $this->get_file_extension( $view_root, $template_name );
     $view_data      = $this->view_data;
@@ -161,43 +161,15 @@ class View_Factory extends Factory {
     );
   }
 
-  /**
-   * Given the 'object'-like path, determine the root
-   * directory for the view
-   */
-  private function get_view_root() {
-    $parts = explode( '.', $this->view_name );
-
-    if ( count( $parts ) <= 1 ) {
-      return '';
-    } else {
-      // There may be more than one dot!
-
-      $dot_position = strrpos( $this->view_name, '.' );
-      $suffix = substr( $this->view_name, 0, $dot_position );
-      $suffix = str_replace( '.', '/', $suffix );
-
-      return $suffix;
-    }
-  }
 
   /**
    * Given the 'object'-like path, determine the template
-   * name for the view
+   * name for the view.
+   * eg: $this->view_name = 'blah.foo'
+   *   get_template_name() returns 'blah/foo'
    */
   private function get_template_name() {
-    $parts = explode( '.', $this->view_name );
-
-    if ( count( $parts ) <= 1 ) {
-      return $parts[0];
-    } else {
-      // There may be more than one dot!
-
-      $dot_position = strrpos( $this->view_name, '.' );
-      $suffix = substr( $this->view_name, $dot_position + 1 );
-
-      return $suffix;
-    }
+    return str_replace('.', '/' , $this->view_name );
   }
 
   /**

--- a/src/view/extensions/handlebars-view.php
+++ b/src/view/extensions/handlebars-view.php
@@ -20,7 +20,7 @@ abstract class Handlebars_View extends View {
    * under the $path_to_views folder path.
    *
    * @constructor
-   * @param $view_root String|Boolean Use false if you are not using views
+   * @param $view_root String|Boolean Use false if you are not rendering views from files
    * @param $path_to_view String|Array Use to override the path to the views
    */
   protected function __construct( $view_root = '', $path_to_views = null ) {

--- a/src/view/extensions/handlebars-view.php
+++ b/src/view/extensions/handlebars-view.php
@@ -37,18 +37,10 @@ abstract class Handlebars_View extends View {
         $path_to_views = Configuration::get_instance()->get( 'path_to_views' );
       }
 
-      if ( is_array( $path_to_views ) ) {
-        $paths_to_load_views = array_map( function( $item ) {
-            return $item . '/' . $this->view_root;
-        }, $path_to_views );
-      } else {
-        $paths_to_load_views = $path_to_views . '/' . $this->view_root;
-      }
-
       $this->engine = new \Handlebars\Handlebars(
           array(
-            'loader' => new \Handlebars\Loader\FilesystemLoader( $paths_to_load_views ),
-            'partials_loader' => new \Handlebars\Loader\FilesystemLoader( $paths_to_load_views ),
+            'loader' => new \Handlebars\Loader\FilesystemLoader( $path_to_views ),
+            'partials_loader' => new \Handlebars\Loader\FilesystemLoader( $path_to_views ),
           )
       );
     }

--- a/src/view/extensions/handlebars-view.php
+++ b/src/view/extensions/handlebars-view.php
@@ -34,17 +34,15 @@ abstract class Handlebars_View extends View {
       }
 
       if ( null == $path_to_views ) {
-        $dir = Configuration::get_instance()->get( 'path_to_views' );
-      } else {
-        $dir = $path_to_views;
+        $path_to_views = Configuration::get_instance()->get( 'path_to_views' );
       }
 
-      if ( is_array( $dir ) ) {
+      if ( is_array( $path_to_views ) ) {
         $paths_to_load_views = array_map( function( $item ) {
             return $item . '/' . $this->view_root;
-        }, $dir );
+        }, $path_to_views );
       } else {
-        $paths_to_load_views = $dir . '/' . $this->view_root;
+        $paths_to_load_views = $path_to_views . '/' . $this->view_root;
       }
 
       $this->engine = new \Handlebars\Handlebars(

--- a/src/view/implementations/simple-handlebars-view.php
+++ b/src/view/implementations/simple-handlebars-view.php
@@ -11,8 +11,8 @@ class Simple_Handlebars_View extends Handlebars_View {
   protected $template_name;
   protected $callback;
 
-  public function __construct( $view_root, $template_name, $callback ) {
-    parent::__construct( $view_root );
+  public function __construct( $view_root, $template_name, $callback, $path_to_views = null ) {
+    parent::__construct( $view_root, $path_to_views );
     $this->template_name = $template_name;
     $this->callback      = $callback;
   }

--- a/tests/integration/view-factory-test.php
+++ b/tests/integration/view-factory-test.php
@@ -21,4 +21,14 @@ class View_Factory_Test extends \PHPUnit_Framework_TestCase {
 
     $this->assertEquals( 'I am handlebars!', $view->content );
   }
+
+  function test_view_factory_creates_handlebars_output_with_custom_view_path() {
+    Configuration::get_instance()->reset();
+
+    $view_factory = new View_Factory( 'test', dirname( __DIR__ ) . '/support/views' );
+
+    $view = $view_factory->build();
+
+    $this->assertEquals( 'I am handlebars!', $view->content );
+  }
 }

--- a/tests/unit/view-factory-test.php
+++ b/tests/unit/view-factory-test.php
@@ -50,6 +50,17 @@ class View_Factory_Test extends \PHPUnit_Framework_TestCase {
     $this->view_factory->build();
   }
 
+  function test_build_uses_overridden_path_configuration() {
+    Configuration::get_instance()->set( 'path_to_views', 'global_path' );
+    $this->view_factory = new View_Factory( 'view.na' , 'overridden_path');
+
+    $mock = create_function_mock( $this, 'glob', 1 );
+    $mock->with( 'overridden_path/view/na.*' )
+     ->will( $this->returnValue( [] ) );
+
+    $this->view_factory->build();
+  }
+
   function test_build_uses_dot_notation_for_paths() {
     Configuration::get_instance()->set( 'path_to_views', 'test_path' );
 


### PR DESCRIPTION
Since the folder path up to the view was used to create the file loader all view paths had to have all the same sub folder paths defined, thats totally not ideal. I've moved the folder path back on to the template name and off the path used to construct the file loader, so that now multiple view paths can define different or overlapping sub folders and they can actually co-exist. 

This should finally solve all aspects of #73 